### PR TITLE
Migrated to hooks

### DIFF
--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1,5 +1,5 @@
-import 'package:native_assets_cli/code_assets_builder.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> args) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,13 +13,14 @@ platforms:
   windows:
 
 environment:
-  sdk: ^3.5.4
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   ffi: ^2.1.3
-  native_assets_cli: ^0.11.0
-  native_toolchain_c: ^0.8.0 
- 
+  hooks: ^0.19.0
+  native_toolchain_c: ^0.16.1
+  code_assets: ^0.19.0
+
 dev_dependencies:
   test: ^1.25.8
   very_good_analysis: ^6.0.0


### PR DESCRIPTION
Hi

I wasn't able to compile it on 3.8.x due to this

```
stderr:
  Unhandled exception:
FormatException: No value was provided for required key: version
#0      MapJsonUtils.get (package:native_assets_cli/src/json_utils.dart:58:7)
```

And it seemed like it was caused by migration to hooks from native assets cli. With these updated dependencies it seems to be working on 3.9.0-241.0.dev dart. 

Sorry if it's not relevant, and you wanted to migrate later in a different way(or you wanted to wait for a stable release of dart that would support it or something else). Just thought it won't be nice of me to make it work in the fork but don't do the PR. Thank you very much for developing this awesome project btw!
